### PR TITLE
Move build script to postinstall on package.json

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run build -- --minify && NODE_PATH=. node app
+web: NODE_PATH=. node app

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "standard",
     "start": "NODE_PATH=. DEBUG='billtracker*' nodemon app",
     "test": "npm run lint",
-    "watch": "npm run build && gulp watch"
+    "watch": "npm run build && gulp watch",
+    "postinstall": "npm run build -- --minify"
   },
   "dependencies": {
     "async": "^1.5.2",


### PR DESCRIPTION
If we do the build on run, the process takes too long and Heroku halts :fire:, causing to never run the server.