### PR TITLE
Fix bill-body width

### DIFF
--- a/lib/bills/index.styl
+++ b/lib/bills/index.styl
@@ -16,7 +16,7 @@
   .bill-body
     margin-left: auto !important
     margin-right: auto !important
-    width: 455px !important
+    width: 455px
 
     [bill-contents]
       font-size: .9rem


### PR DESCRIPTION
Erase "!important" on .bill-body width to fix the rendering.